### PR TITLE
Fix F&O data flow robustness + dedupe Telegram alerts to once per session

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4239,10 +4239,15 @@ function renderDashboard() {
 
   // Render Flow Strength Meter
 // Wait 2 seconds for JS execution before doing the rest
-  // ── Render F&O Data (if available in latest) ───────────────────────────────
-  const latestFno = dailyData.find(d => d.fii_idx_fut_long !== undefined) || latest;
+  // ── Render F&O Data ────────────────────────────────────────────────────────
+  // NSE publishes participant-OI later than cash, so the newest session can have
+  // cash but all-zero F&O. Show the most recent session that actually HAS F&O
+  // rather than a misleading all-zeros panel.
+  const _hasRealFno = d => d && ((d.fii_idx_fut_long || 0) !== 0 || (d.fii_idx_fut_short || 0) !== 0);
+  const latestFno = dailyData.find(_hasRealFno) || latest;
+  const fnoIsStale = latestFno && latest && latestFno.d !== latest.d;
 
-  if (latestFno.fii_idx_fut_long !== undefined) {
+  if (_hasRealFno(latestFno)) {
     const fnl = n => n ? n.toLocaleString('en-IN') : '0';
     const fillRatio = (l, s, bar, reverseColor = false) => {
       document.getElementById(bar).style.width = (l+s > 0) ? `${(l/(l+s))*100}%` : '50%';
@@ -4297,12 +4302,18 @@ function renderDashboard() {
     // Date Update for F&O Header
     const fnoDt = parseNSEDate(latestFno.d);
     let fnoDtStr = fnoDt ? fnoDt.toLocaleDateString('en-GB', {weekday:'long', day:'numeric', month:'long', year:'numeric'}) : latestFno.d;
-    document.getElementById('fnoDate').innerText = `Data for: ${fnoDtStr}`;
+    document.getElementById('fnoDate').innerText = fnoIsStale
+      ? `Data for: ${fnoDtStr} · F&O for ${latest.d} pending (NSE publishes it later)`
+      : `Data for: ${fnoDtStr}`;
 
     // F&O Historical Chart
     if (typeof renderFnoHistoryChart === 'function') {
       renderFnoHistoryChart();
     }
+  } else {
+    // No F&O anywhere in the loaded history
+    const fnoDateEl = document.getElementById('fnoDate');
+    if (fnoDateEl) fnoDateEl.innerText = 'F&O positioning data not available yet';
   }
 
   const fNetAbs = Math.abs(latest.fn);
@@ -4454,7 +4465,9 @@ function renderSectorTape() {
 function renderCommandCenter() {
   if (!dailyData || !dailyData.length) return;
   const latest = dailyData[0];
-  const latestFno = dailyData.find(d => d.fii_idx_fut_long !== undefined) || latest;
+  // Most recent session with REAL F&O (newest day may be cash-only until NSE
+  // publishes participant-OI later in the evening)
+  const latestFno = dailyData.find(d => (d.fii_idx_fut_long || 0) !== 0 || (d.fii_idx_fut_short || 0) !== 0) || latest;
   const market = getFlowScore(dailyData, 5);
   const stock = getStockScore(dailyData);
   const fno = getFnoSentiment(latestFno);
@@ -4482,7 +4495,8 @@ function renderCommandCenter() {
   set('cmd-anomaly-counts', `${bloodbath} / ${absorption}`);
   set('cmd-divergence-count', `Divergence ${divergence}`);
 
-  set('cmd-fno-date', latestFno?.d ? `F&O data: ${latestFno.d}` : 'F&O data pending');
+  const _fnoReal = latestFno && ((latestFno.fii_idx_fut_long || 0) !== 0 || (latestFno.fii_idx_fut_short || 0) !== 0);
+  set('cmd-fno-date', !_fnoReal ? 'F&O data pending' : (latestFno.d !== latest.d ? `F&O: ${latestFno.d} (${latest.d} pending)` : `F&O data: ${latestFno.d}`));
   const signedContracts = (value) => `${Number(value || 0) >= 0 ? '+' : ''}${Number(value || 0).toLocaleString('en-IN')}`;
   const futNet = Number(latestFno.fii_idx_fut_long || 0) - Number(latestFno.fii_idx_fut_short || 0);
   const callNet = Number(latestFno.fii_idx_call_long || 0) - Number(latestFno.fii_idx_call_short || 0);

--- a/scripts/fetch_data.js
+++ b/scripts/fetch_data.js
@@ -233,6 +233,89 @@ function validateData(data) {
     return fields.every(f => isFinite(data[f]));
 }
 
+// True when a row actually carries F&O participant-OI data
+function rowHasFao(row) {
+    return !!row && ((row.fii_idx_fut_long || 0) !== 0 || (row.fii_idx_fut_short || 0) !== 0);
+}
+
+// F&O summary used in notification payloads
+function buildFaoSummary(d) {
+    return {
+        sentiment: d.sentiment_score > 60 ? 'Bullish' : d.sentiment_score < 40 ? 'Bearish' : 'Neutral',
+        pcr: d.pcr,
+        fii_fut_net: d.fii_idx_fut_net,
+        fii_call_net: d.fii_idx_call_net,
+        fii_put_net: d.fii_idx_put_net
+    };
+}
+
+// Apply parsed F&O data onto a row (recomputes nets, PCR, sentiment).
+// Returns true if FII F&O data was applied. Does NOT touch cash fields.
+function applyFao(out, fao) {
+    let applied = false;
+    if (fao && fao["FII"]) {
+        const f = fao["FII"];
+        out.fii_idx_fut_long = f.idx_fut_long; out.fii_idx_fut_short = f.idx_fut_short; out.fii_idx_fut_net = f.idx_fut_long - f.idx_fut_short;
+        out.fii_stk_fut_long = f.stk_fut_long; out.fii_stk_fut_short = f.stk_fut_short; out.fii_stk_fut_net = f.stk_fut_long - f.stk_fut_short;
+        out.fii_idx_call_long = f.idx_call_long; out.fii_idx_call_short = f.idx_call_short; out.fii_idx_call_net = f.idx_call_long - f.idx_call_short;
+        out.fii_idx_put_long = f.idx_put_long; out.fii_idx_put_short = f.idx_put_short; out.fii_idx_put_net = f.idx_put_long - f.idx_put_short;
+
+        out.pcr = f.idx_call_short > 0 ? parseFloat((f.idx_put_short / f.idx_call_short).toFixed(2)) : 1.0;
+
+        let sentiment = 50;
+        // Clamp each factor to ±15 to prevent single-factor domination
+        sentiment += Math.max(-15, Math.min(15, (out.fii_net || 0) / 500));
+        sentiment += Math.max(-15, Math.min(15, out.fii_idx_fut_net / 10000));
+        if (out.pcr > 1.3) sentiment -= 8;
+        else if (out.pcr > 1.1) sentiment -= 4;
+        if (out.pcr < 0.7) sentiment += 8;
+        else if (out.pcr < 0.9) sentiment += 4;
+        out.sentiment_score = Math.min(100, Math.max(5, parseFloat(sentiment.toFixed(1))));
+        applied = true;
+    }
+    if (fao && fao["DII"]) {
+        const d = fao["DII"];
+        out.dii_idx_fut_long = d.idx_fut_long; out.dii_idx_fut_short = d.idx_fut_short; out.dii_idx_fut_net = d.idx_fut_long - d.idx_fut_short;
+        out.dii_stk_fut_long = d.stk_fut_long; out.dii_stk_fut_short = d.stk_fut_short; out.dii_stk_fut_net = d.stk_fut_long - d.stk_fut_short;
+        applied = true;
+    }
+    return applied;
+}
+
+// NSE publishes the participant-OI (F&O) file LATER than cash — sometimes after
+// the evening fetch window closes. On each run, retry F&O for the most recent
+// cash-only rows and merge it in without disturbing the cash figures. Cheap when
+// nothing is missing (rows that already have F&O make no HTTP calls).
+// Returns the list of dates that were filled.
+async function backfillMissingFao() {
+    const history = readJSON('history.json', []);
+    if (!history.length) return [];
+    const recent = [...history].sort((a, b) => compareDates(b.date, a.date)).slice(0, 4);
+    const filled = [];
+    for (const row of recent) {
+        if (row._source !== 'fetch-pipeline' || rowHasFao(row)) continue;
+        let csv = null;
+        try { csv = await fetchFaoOi(row.date); } catch { /* not published yet */ }
+        if (!csv) continue;
+        const fao = parseFao(csv);
+        if (applyFao(row, fao) && rowHasFao(row)) {
+            row._fao_summary = buildFaoSummary(row);
+            row._fao_backfilled_at = new Date().toISOString();
+            filled.push(row.date);
+        }
+    }
+    if (filled.length) {
+        writeJSON('history.json', history);
+        const latest = readJSON('latest.json', null);
+        if (latest && filled.includes(latest.date)) {
+            const updated = history.find(r => r.date === latest.date);
+            if (updated) writeJSON('latest.json', updated);
+        }
+        console.log(`[F&O BACKFILL] Filled F&O for: ${filled.join(', ')}`);
+    }
+    return filled;
+}
+
 // ── Transform data ───────────────────────────────────────────────────────────
 async function transformData(rawCash, rawFaoCsv) {
     const out = {
@@ -264,35 +347,7 @@ async function transformData(rawCash, rawFaoCsv) {
     }
 
     if (out.date && rawFaoCsv) {
-        const fao = parseFao(rawFaoCsv);
-        if (fao["FII"]) {
-            const f = fao["FII"];
-            out.fii_idx_fut_long = f.idx_fut_long; out.fii_idx_fut_short = f.idx_fut_short; out.fii_idx_fut_net = f.idx_fut_long - f.idx_fut_short;
-            out.fii_stk_fut_long = f.stk_fut_long; out.fii_stk_fut_short = f.stk_fut_short; out.fii_stk_fut_net = f.stk_fut_long - f.stk_fut_short;
-            out.fii_idx_call_long = f.idx_call_long; out.fii_idx_call_short = f.idx_call_short; out.fii_idx_call_net = f.idx_call_long - f.idx_call_short;
-            out.fii_idx_put_long = f.idx_put_long; out.fii_idx_put_short = f.idx_put_short; out.fii_idx_put_net = f.idx_put_long - f.idx_put_short;
-            
-            if (f.idx_call_short > 0) {
-                out.pcr = parseFloat((f.idx_put_short / f.idx_call_short).toFixed(2));
-            } else {
-                out.pcr = 1.0;
-            }
-
-            let sentiment = 50;
-            // Clamp each factor to ±15 to prevent single-factor domination
-            sentiment += Math.max(-15, Math.min(15, out.fii_net / 500));
-            sentiment += Math.max(-15, Math.min(15, out.fii_idx_fut_net / 10000));
-            if (out.pcr > 1.3) sentiment -= 8;
-            else if (out.pcr > 1.1) sentiment -= 4;
-            if (out.pcr < 0.7) sentiment += 8;
-            else if (out.pcr < 0.9) sentiment += 4;
-            out.sentiment_score = Math.min(100, Math.max(5, parseFloat(sentiment.toFixed(1))));
-        }
-        if (fao["DII"]) {
-            const d = fao["DII"];
-            out.dii_idx_fut_long = d.idx_fut_long; out.dii_idx_fut_short = d.idx_fut_short; out.dii_idx_fut_net = d.idx_fut_long - d.idx_fut_short;
-            out.dii_stk_fut_long = d.stk_fut_long; out.dii_stk_fut_short = d.stk_fut_short; out.dii_stk_fut_net = d.stk_fut_long - d.stk_fut_short;
-        }
+        applyFao(out, parseFao(rawFaoCsv));
     }
 
     out._updated_at = new Date().toLocaleString("en-IN", { timeZone: "Asia/Kolkata", dateStyle: 'medium', timeStyle: 'short' }) + " IST";
@@ -342,17 +397,29 @@ async function fetchAndProcessData() {
             return null;
         }
 
+        // Recover F&O for any recent cash-only rows (NSE publishes it late).
+        // Cheap no-op when nothing is missing.
+        let filledNow = [];
+        try { filledNow = await backfillMissingFao(); } catch (e) { console.warn("  ⚠️ F&O backfill skipped:", e.message); }
+
         // Smart skip: check if we already have this exact data.
         // Only trust rows the real pipeline wrote — seeded/estimated rows
         // (_source: 'historical-seed' / 'backfill-estimated') must be replaced
         // by real data, never re-published to latest.json.
         const history = readJSON('history.json', []);
         const existing = history.find(r => r.date === targetDate && r._source === 'fetch-pipeline');
-        const hasFaoData = existing && (existing.fii_idx_fut_long > 0 || existing.fii_idx_fut_short > 0);
+        const hasFaoData = rowHasFao(existing);
         if (existing && existing.fii_net !== 0 && hasFaoData) {
+            writeJSON('latest.json', existing);
+            // If F&O *just* arrived via backfill, surface it (non-skipped) so the
+            // F&O notification fires once. Otherwise it's old news → skip.
+            if (filledNow.includes(targetDate)) {
+                console.log(`⚡ F&O just recovered for ${targetDate} — surfacing for notification.`);
+                logFetch({ success: true, date: targetDate, action: "fao-recovered" });
+                return existing;
+            }
             console.log(`ℹ️ Data for ${targetDate} already exists (cash+F&O). Skipping store.`);
             logFetch({ success: true, date: targetDate, action: "skipped" });
-            writeJSON('latest.json', existing);
             return { ...existing, _skipped: true };
         }
         if (existing && existing.fii_net !== 0 && !hasFaoData) {
@@ -364,14 +431,8 @@ async function fetchAndProcessData() {
 
         if (!validateData(data)) throw new Error(`Validation failed for ${data.date}`);
 
-        // Enrich with F&O summary for notification payloads
-        data._fao_summary = {
-            sentiment: data.sentiment_score > 60 ? 'Bullish' : data.sentiment_score < 40 ? 'Bearish' : 'Neutral',
-            pcr: data.pcr,
-            fii_fut_net: data.fii_idx_fut_net,
-            fii_call_net: data.fii_idx_call_net,
-            fii_put_net: data.fii_idx_put_net
-        };
+        // Enrich with F&O summary for notification payloads (only when F&O is real)
+        if (rowHasFao(data)) data._fao_summary = buildFaoSummary(data);
 
         saveToHistory(data);
         writeJSON('latest.json', data);
@@ -392,4 +453,4 @@ if (require.main === module) {
     fetchAndProcessData().catch(() => process.exit(1));
 }
 
-module.exports = { fetchAndProcessData, getLatestData, getHistoryData, getSectorData, getFetchLogs };
+module.exports = { fetchAndProcessData, getLatestData, getHistoryData, getSectorData, getFetchLogs, backfillMissingFao, rowHasFao };

--- a/server.js
+++ b/server.js
@@ -100,6 +100,7 @@ async function broadcastNotification(payload, category = 'cash') {
 }
 
 let axios, cron, fetchAndProcessData, getLatestData, getHistoryData, getFetchLogs, getSectorData;
+let backfillMissingFao = async () => [];
 let fetchAllNSDL;
 
 try {
@@ -123,6 +124,7 @@ try {
     getHistoryData = fetchModule.getHistoryData;
     getFetchLogs = fetchModule.getFetchLogs;
     getSectorData = fetchModule.getSectorData;
+    if (fetchModule.backfillMissingFao) backfillMissingFao = fetchModule.backfillMissingFao;
     console.log('[BOOT] fetch_data loaded ✓');
 } catch (e) {
     console.error('[BOOT] fetch_data failed:', e.message);
@@ -521,18 +523,52 @@ let tgMessages;
 try { tgMessages = require('./telegram-messages'); } catch (e) { console.warn('[BOOT] telegram-messages not loaded:', e.message); }
 
 // ── Category-specific notification builder ───────────────────────────────────
-// Dedupe guard: the fetch pipeline can run multiple times per evening (cash data
-// lands first, F&O later) and /api/refresh is publicly callable — only notify
-// once per category per trading date.
-const _notifiedDates = { cash: null, fao: null, divergence: null };
+// Dedupe is PERSISTED to disk so a category alerts exactly once per trading date,
+// even though the fetch pipeline runs every ~15 min (cash lands first, F&O later),
+// /api/refresh is publicly callable, and the process restarts on every deploy.
+const NOTIFY_LOG_PATH = path.join(__dirname, 'data', 'notify_log.json');
+function _loadNotifyLog() {
+    try { return JSON.parse(fs.readFileSync(NOTIFY_LOG_PATH, 'utf8')); } catch { return {}; }
+}
+function alreadyNotified(date, category) {
+    const log = _loadNotifyLog();
+    return !!(log[date] && log[date][category]);
+}
+function markNotified(date, category) {
+    const log = _loadNotifyLog();
+    if (!log[date]) log[date] = {};
+    log[date][category] = new Date().toISOString();
+    // Prune to the 40 most-recent dates (by latest timestamp in each entry)
+    const dates = Object.keys(log);
+    if (dates.length > 40) {
+        dates.sort((a, b) => {
+            const ta = Math.max(...Object.values(log[a]).map(t => Date.parse(t) || 0));
+            const tb = Math.max(...Object.values(log[b]).map(t => Date.parse(t) || 0));
+            return tb - ta;
+        });
+        const pruned = {};
+        dates.slice(0, 40).forEach(d => { pruned[d] = log[d]; });
+        Object.keys(log).forEach(k => delete log[k]);
+        Object.assign(log, pruned);
+    }
+    try {
+        const tmp = NOTIFY_LOG_PATH + '.tmp';
+        fs.writeFileSync(tmp, JSON.stringify(log, null, 2), 'utf8');
+        fs.renameSync(tmp, NOTIFY_LOG_PATH);
+    } catch (e) { console.warn('[NOTIFY] Could not persist notify log:', e.message); }
+}
+function _faoPresent(data) {
+    return (data.fii_idx_fut_long || 0) !== 0 || (data.fii_idx_fut_short || 0) !== 0 || (data.pcr || 0) > 0;
+}
+
 function sendDataNotifications(data) {
     const fmtCr = (v) => `${v >= 0 ? '+' : '-'}₹${Math.abs(v).toLocaleString('en-IN')} Cr`;
     const fmtContracts = (v) => `${v >= 0 ? '+' : ''}${(v / 1000).toFixed(0)}K`;
 
-    // 1. Cash flow notification
-    const sendCash = _notifiedDates.cash !== data.date;
+    // 1. Cash flow notification — once per date
+    const sendCash = !alreadyNotified(data.date, 'cash');
     if (sendCash) {
-        _notifiedDates.cash = data.date;
+        markNotified(data.date, 'cash');
         broadcastNotification({
             title: '📊 Institutional Cash Flows',
             body: `${data.date} — FII: ${fmtCr(data.fii_net)} | DII: ${fmtCr(data.dii_net)}`,
@@ -540,11 +576,12 @@ function sendDataNotifications(data) {
         }, 'cash');
     }
 
-    // 2. F&O sentiment notification
-    const hasFao = data._fao_summary || data.pcr;
-    const sendFao = hasFao && _notifiedDates.fao !== data.date;
+    // 2. F&O sentiment notification — once per date, ONLY when F&O is genuinely
+    //    present (it publishes later than cash; an all-zeros row must not consume
+    //    the alert before the real data arrives)
+    const sendFao = _faoPresent(data) && !alreadyNotified(data.date, 'fao');
     if (sendFao) {
-        _notifiedDates.fao = data.date;
+        markNotified(data.date, 'fao');
         const summary = data._fao_summary || {};
         const sentiment = summary.sentiment || (data.sentiment_score > 60 ? 'Bullish' : data.sentiment_score < 40 ? 'Bearish' : 'Neutral');
         const pcr = summary.pcr || data.pcr || 0;
@@ -592,8 +629,8 @@ function sendDataNotifications(data) {
 
             // C. Divergence alert (if signal is active for today)
             if (flowDiv && flowDiv.last_signal && flowDiv.last_signal !== 'NONE' && flowDiv.last_signal_date === data.date &&
-                _notifiedDates.divergence !== data.date) {
-                _notifiedDates.divergence = data.date;
+                !alreadyNotified(data.date, 'divergence')) {
+                markNotified(data.date, 'divergence');
                 setTimeout(() => {
                     const divMsg = tgMessages.buildDivergenceMessage(flowDiv, data);
                     telegram.broadcastTelegram(divMsg, TG_TOKEN, axios, TG_CHANNEL_ID).catch(err =>
@@ -1377,6 +1414,26 @@ app.listen(PORT, '0.0.0.0', () => {
 
             // NSDL sector data — check daily at 10:00 AM IST (smart skip if unchanged)
             cron.schedule('30 4 * * 1-5', () => runNSDLFetch(), CRON_OPTS);  // 10:00 AM IST
+
+            // F&O recovery — NSE sometimes publishes participant-OI after the
+            // evening fetch window closes. Backfill any cash-only rows and fire
+            // the (still-pending) F&O alert once. 10 PM IST + next-day 8 AM IST.
+            async function runFaoRecovery(label) {
+                try {
+                    const filled = await backfillMissingFao();
+                    if (!filled || !filled.length) return;
+                    console.log(`[${new Date().toISOString()}] ${label} recovered F&O: ${filled.join(', ')}`);
+                    const latest = getLatestData();
+                    if (latest && filled.includes(latest.date) && !latest._skipped) {
+                        sseBroadcast('data-update', { date: latest.date, fii_net: latest.fii_net, dii_net: latest.dii_net, ts: new Date().toISOString() });
+                        sendDataNotifications(latest); // cash already deduped → only F&O fires
+                    }
+                } catch (err) {
+                    console.error(`[${new Date().toISOString()}] ${label} F&O recovery failed:`, err.message);
+                }
+            }
+            cron.schedule('30 16 * * 1-5', () => runFaoRecovery('Late-evening'), CRON_OPTS); // 10:00 PM IST
+            cron.schedule('30 2 * * 2-6', () => runFaoRecovery('Next-morning'), CRON_OPTS);  // 08:00 AM IST (Tue–Sat)
 
             // Weekly institutional digest — Friday 8:00 PM IST
             if (agentRunner) {


### PR DESCRIPTION
Fixes the two issues reported: derivative (F&O) data flow not working well, and Telegram sending repeated alerts.

## Derivative (F&O) data flow
**Root cause:** NSE publishes the participant-OI (F&O) file *later* than cash. The newest session often carries cash with all-zero F&O until NSE catches up — and there was no backfill, so a day's F&O was lost once the evening cron window closed. On the frontend, the F&O finder matched the zero row (`0 !== undefined`), so the F&O tab showed a misleading all-zeros panel.

**Fixes:**
- `backfillMissingFao()` retries F&O for recent cash-only rows on every pipeline run and merges it in **without disturbing cash figures** (verified: cash preserved, PCR/sentiment recomputed). Cheap no-op when nothing is missing.
- Late-evening (10 PM IST) + next-morning (8 AM IST) recovery crons fill late F&O and fire the still-pending F&O alert once.
- Pipeline surfaces a just-recovered F&O row so its notification fires.
- `_fao_summary` only set when F&O is genuinely present (was always set, even all-zeros).
- Frontend F&O tab and command-center snapshot show the most recent session that actually has F&O, with a clear "F&O for `<date>` pending" note.
- Shared `applyFao()` helper (removes duplicated F&O/PCR/sentiment logic).

## Telegram "so many alerts" → once per data publication
**Root cause:** the dedupe guard was in-memory only, so every Hostinger deploy/restart reset it and the 15-minute cron (plus public `/api/refresh`) re-sent everything. The F&O alert was also gated on `_fao_summary` existing, which was always true — so it fired a junk "PCR: 0" alert and consumed the alert before real F&O arrived.

**Fixes:**
- Disk-persisted `notify_log.json` keyed by date+category — cash, F&O and divergence each alert **exactly once per trading date**, surviving restarts/cron-cadence/refresh hits (verified: 1 cash + 1 F&O across 10 simulated runs and a restart; pruned to 40 dates).
- F&O alert gated on genuine F&O presence, so an early all-zeros row no longer steals the alert.

## Verification
- F&O merge unit-tested (cash preserved, PCR = put_short/call_short correct)
- Dedupe + pruning unit-tested (once-per-category, survives restart)
- Browser-verified F&O fallback rendering + "pending" note; no page JS errors
- `npm run test:ui` passes (34 markers); all 31 feature checks pass; Telegram commands OK

https://claude.ai/code/session_01AtjCSijeVz51kgDCabjSSy

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtjCSijeVz51kgDCabjSSy)_