### PR TITLE
fix: upgrade axios to 1.15.1, 0.31.1 (CVE-2026-42033)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "fii-dii-dashboard",
       "version": "2.0.0",
       "dependencies": {
-        "axios": "^1.6.8",
+        "axios": "^1.15.1",
         "compression": "^1.8.1",
         "cors": "^2.8.5",
         "csv-parse": "^5.5.5",
@@ -85,9 +85,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
+      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "axios": "^1.6.8",
+    "axios": "^1.15.1",
     "compression": "^1.8.1",
     "cors": "^2.8.5",
     "csv-parse": "^5.5.5",


### PR DESCRIPTION
## Summary
Upgrade axios from 1.14.0 to 1.15.1, 0.31.1 to fix CVE-2026-42033.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-42033 |
| **Severity** | HIGH |
| **Scanner** | trivy |
| **Rule** | `CVE-2026-42033` |
| **File** | `package-lock.json` |
| **Assessment** | Likely exploitable |

**Description**: axios: Axios: HTTP Transport Hijacking via Prototype Pollution

## Evidence

**Scanner confirmation**: trivy rule `CVE-2026-42033` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a web service - vulnerabilities in request handlers are directly exploitable by remote attackers.

## Changes
- `package.json`
- `package-lock.json`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
